### PR TITLE
Bump scss-tokenizer and node-sass in /vue

### DIFF
--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -1214,16 +1214,19 @@
       }
     },
     "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/color-convert": {
@@ -3485,9 +3488,9 @@
       "peer": true
     },
     "node_modules/node-sass": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-7.0.1.tgz",
-      "integrity": "sha512-uMy+Xt29NlqKCFdFRZyXKOTqGt+QaKHexv9STj2WeLottnlqZEEWx6Bj0MXNthmFRRdM/YwyNo/8Tr46TOM0jQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-7.0.3.tgz",
+      "integrity": "sha512-8MIlsY/4dXUkJDYht9pIWBhMil3uHmE8b/AdJPjmFn1nBx9X9BASzfzmsCy0uCCb8eqI3SYYzVPDswWqSx7gjw==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -3505,7 +3508,7 @@
         "node-gyp": "^8.4.1",
         "npmlog": "^5.0.0",
         "request": "^2.88.0",
-        "sass-graph": "4.0.0",
+        "sass-graph": "^4.0.1",
         "stdout-stream": "^1.4.0",
         "true-case-path": "^1.0.2"
       },
@@ -4214,16 +4217,16 @@
       }
     },
     "node_modules/sass-graph": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-4.0.0.tgz",
-      "integrity": "sha512-WSO/MfXqKH7/TS8RdkCX3lVkPFQzCgbqdGsmSKq6tlPU+GpGEsa/5aW18JqItnqh+lPtcjifqdZ/VmiILkKckQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-4.0.1.tgz",
+      "integrity": "sha512-5YCfmGBmxoIRYHnKK2AKzrAkCoQ8ozO+iumT8K4tXJXRVCPf+7s1/9KxTSW3Rbvf+7Y7b4FR3mWyLnQr3PHocA==",
       "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
         "glob": "^7.0.0",
         "lodash": "^4.17.11",
-        "scss-tokenizer": "^0.3.0",
+        "scss-tokenizer": "^0.4.3",
         "yargs": "^17.2.1"
       },
       "bin": {
@@ -4291,15 +4294,15 @@
       }
     },
     "node_modules/scss-tokenizer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.3.0.tgz",
-      "integrity": "sha512-14Zl9GcbBvOT9057ZKjpz5yPOyUWG2ojd9D5io28wHRYsOrs7U95Q+KNL87+32p8rc+LvDpbu/i9ZYjM9Q+FsQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.4.3.tgz",
+      "integrity": "sha512-raKLgf1LI5QMQnG+RxHz6oK0sL3x3I4FN2UDLqgLOGO8hodECNnNh5BXn7fAyBxrA8zVzdQizQ6XjNJQ+uBwMw==",
       "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
-        "js-base64": "^2.4.3",
-        "source-map": "^0.7.1"
+        "js-base64": "^2.4.9",
+        "source-map": "^0.7.3"
       }
     },
     "node_modules/scss-tokenizer/node_modules/source-map": {
@@ -5236,20 +5239,20 @@
       "dev": true
     },
     "node_modules/yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
       "dev": true,
       "optional": true,
       "peer": true,
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
         "node": ">=12"
@@ -5267,9 +5270,9 @@
       }
     },
     "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "optional": true,
       "peer": true,
@@ -6269,15 +6272,15 @@
       "peer": true
     },
     "cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "optional": true,
       "peer": true,
       "requires": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
       }
     },
@@ -7980,9 +7983,9 @@
       "peer": true
     },
     "node-sass": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-7.0.1.tgz",
-      "integrity": "sha512-uMy+Xt29NlqKCFdFRZyXKOTqGt+QaKHexv9STj2WeLottnlqZEEWx6Bj0MXNthmFRRdM/YwyNo/8Tr46TOM0jQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-7.0.3.tgz",
+      "integrity": "sha512-8MIlsY/4dXUkJDYht9pIWBhMil3uHmE8b/AdJPjmFn1nBx9X9BASzfzmsCy0uCCb8eqI3SYYzVPDswWqSx7gjw==",
       "dev": true,
       "optional": true,
       "peer": true,
@@ -7999,7 +8002,7 @@
         "node-gyp": "^8.4.1",
         "npmlog": "^5.0.0",
         "request": "^2.88.0",
-        "sass-graph": "4.0.0",
+        "sass-graph": "^4.0.1",
         "stdout-stream": "^1.4.0",
         "true-case-path": "^1.0.2"
       }
@@ -8525,16 +8528,16 @@
       }
     },
     "sass-graph": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-4.0.0.tgz",
-      "integrity": "sha512-WSO/MfXqKH7/TS8RdkCX3lVkPFQzCgbqdGsmSKq6tlPU+GpGEsa/5aW18JqItnqh+lPtcjifqdZ/VmiILkKckQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-4.0.1.tgz",
+      "integrity": "sha512-5YCfmGBmxoIRYHnKK2AKzrAkCoQ8ozO+iumT8K4tXJXRVCPf+7s1/9KxTSW3Rbvf+7Y7b4FR3mWyLnQr3PHocA==",
       "dev": true,
       "optional": true,
       "peer": true,
       "requires": {
         "glob": "^7.0.0",
         "lodash": "^4.17.11",
-        "scss-tokenizer": "^0.3.0",
+        "scss-tokenizer": "^0.4.3",
         "yargs": "^17.2.1"
       }
     },
@@ -8561,15 +8564,15 @@
       }
     },
     "scss-tokenizer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.3.0.tgz",
-      "integrity": "sha512-14Zl9GcbBvOT9057ZKjpz5yPOyUWG2ojd9D5io28wHRYsOrs7U95Q+KNL87+32p8rc+LvDpbu/i9ZYjM9Q+FsQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.4.3.tgz",
+      "integrity": "sha512-raKLgf1LI5QMQnG+RxHz6oK0sL3x3I4FN2UDLqgLOGO8hodECNnNh5BXn7fAyBxrA8zVzdQizQ6XjNJQ+uBwMw==",
       "dev": true,
       "optional": true,
       "peer": true,
       "requires": {
-        "js-base64": "^2.4.3",
-        "source-map": "^0.7.1"
+        "js-base64": "^2.4.9",
+        "source-map": "^0.7.3"
       },
       "dependencies": {
         "source-map": {
@@ -9280,26 +9283,26 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
       "dev": true,
       "optional": true,
       "peer": true,
       "requires": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "dependencies": {
         "yargs-parser": {
-          "version": "21.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
           "dev": true,
           "optional": true,
           "peer": true


### PR DESCRIPTION
Bumps [scss-tokenizer](https://github.com/sasstools/scss-tokenizer) and [node-sass](https://github.com/sass/node-sass). These dependencies needed to be updated together.

Updates `scss-tokenizer` from 0.3.0 to 0.4.3
- [Release notes](https://github.com/sasstools/scss-tokenizer/releases)
- [Commits](https://github.com/sasstools/scss-tokenizer/compare/v0.3.0...v0.4.3)

Updates `node-sass` from 7.0.1 to 7.0.3
- [Release notes](https://github.com/sass/node-sass/releases)
- [Changelog](https://github.com/sass/node-sass/blob/master/CHANGELOG.md)
- [Commits](https://github.com/sass/node-sass/compare/v7.0.1...v7.0.3)

---
updated-dependencies:
- dependency-name: scss-tokenizer dependency-type: indirect
- dependency-name: node-sass dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>